### PR TITLE
Add support for fields containing '->'

### DIFF
--- a/src/Checkboxes.php
+++ b/src/Checkboxes.php
@@ -52,7 +52,7 @@ class Checkboxes extends Field
 
     public function resolveAttribute($resource, $attribute = null)
     {
-        $value = data_get($resource, $attribute);
+        $value = data_get($resource, str_replace('->', '.', $attribute));
 
         if(! $value) return json_encode($this->withUnchecked([]));
 


### PR DESCRIPTION
This is modelled after `Laravel\Nova\Fields\Field::resolveAttribute()`. In fact, the parent `Field` class calls `str_replace` on each `data_get`.

The reason to use `->` over `.` is to avoid PHP's automatic conversion of dots to underscores in requests. See http://php.net/variables.external#language.variables.external.dot-in-names